### PR TITLE
Refactor time formatter helper

### DIFF
--- a/src/components/scoreboard/RealtimeScoreboard.tsx
+++ b/src/components/scoreboard/RealtimeScoreboard.tsx
@@ -6,6 +6,7 @@ import { Users, Clock } from "lucide-react";
 import { useGameRealtime } from '@/hooks/useGameRealtime';
 import { supabase } from '@/integrations/supabase/client';
 import type { Advertisement } from '@/types/game';
+import { formatTime } from '@/lib/formatTime';
 
 interface RealtimeScoreboardProps {
   gameId?: string;
@@ -61,11 +62,6 @@ export const RealtimeScoreboard: React.FC<RealtimeScoreboardProps> = ({
     };
   }, [game?.field_id, showAds]);
 
-  const formatTime = (seconds: number) => {
-    const mins = Math.floor(seconds / 60);
-    const secs = Math.floor(seconds % 60);
-    return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
-  };
 
   if (isLoading) {
     return (

--- a/src/components/scoreboard/ScorekeeperControls.tsx
+++ b/src/components/scoreboard/ScorekeeperControls.tsx
@@ -12,6 +12,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { usePenaltyTracking } from '@/hooks/usePenaltyTracking';
 import { useNotifications } from '@/hooks/useNotifications';
 import type { Game } from '@/types/game';
+import { formatTime } from '@/lib/formatTime';
 
 interface ScorekeeperControlsProps {
   game: Game;
@@ -164,11 +165,6 @@ export const ScorekeeperControls: React.FC<ScorekeeperControlsProps> = ({
     }
   };
 
-  const formatTime = (seconds: number) => {
-    const mins = Math.floor(seconds / 60);
-    const secs = Math.floor(seconds % 60);
-    return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
-  };
 
   const getTimeRemaining = (penalty: any) => {
     const expires = new Date(penalty.expires_at);

--- a/src/lib/formatTime.ts
+++ b/src/lib/formatTime.ts
@@ -1,0 +1,5 @@
+export const formatTime = (seconds: number): string => {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+};


### PR DESCRIPTION
## Summary
- add `formatTime` helper in `src/lib`
- use `formatTime` in scoreboard components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867b44f914c832f95a5fb94e8e84c50